### PR TITLE
chore: make current version release-ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Node modules
 node_modules/
 
+# Build output
+*.foxe
+
 # Logs
 logs
 *.log

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,1 @@
+* 2025/07/04 - changed package name to "Autoware Foxglove Extensions", publisher to "TIER IV", version to 0.1.0

--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ Note that this repository may not be maintained and thus the destructive changes
 
 ## Develop
 
-Extension development uses the `npm` package manager to install development dependencies and run build scripts.
+Extension development uses the `yarn` package manager to install development dependencies and run build scripts.
 
-To install extension dependencies, run `npm` from the root of the extension package.
+To install extension dependencies, run `yarn` from the root of the extension package.
 
 ```sh
-npm install
+yarn install
 ```
 
 To build and install the extension into your local Foxglove Studio desktop app, run:
 
 ```sh
-npm run local-install
+yarn run local-install
 ```
 
 Open the `Foxglove Studio` desktop (or `ctrl-R` to refresh if it is already open). Your extension is installed and available within the app.
@@ -41,7 +41,7 @@ Extensions are packaged into `.foxe` files. These files contain the metadata (pa
 Before packaging, make sure to set `name`, `publisher`, `version`, and `description` fields in _package.json_. When ready to distribute the extension, run:
 
 ```sh
-npm run package
+yarn run package
 ```
 
 This command will package the extension into a `.foxe` file in the local directory.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AutowareFoxgloveConverter
+# Autoware Foxglove Extensions
 
 Special thanks to [https://github.com/KhalilSelyan/predictedObjectConverter](https://github.com/KhalilSelyan/predictedObjectConverter) for the inspiration and the code to get started.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Support for Autoware in Foxglove Studio",
   "publisher": "tier4",
   "homepage": "https://github.com/tier4/AutowareFoxgloveExtensions",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "main": "./dist/extension.js",
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "AutowareFoxgloveConverter",
-  "displayName": "AutowareFoxgloveConverter",
-  "description": "",
-  "publisher": "kminoda",
-  "homepage": "",
+  "name": "autoware-foxglove-extensions",
+  "displayName": "Autoware Foxglove Extensions",
+  "description": "Support for Autoware in Foxglove Studio",
+  "publisher": "tier4",
+  "homepage": "https://github.com/tier4/AutowareFoxgloveExtensions",
   "version": "0.0.0",
-  "license": "UNLICENSED",
+  "license": "Apache-2.0",
   "main": "./dist/extension.js",
   "keywords": [],
   "scripts": {


### PR DESCRIPTION
The last [version](https://github.com/kminoda/AutowareFoxgloveConverter/releases/tag/v0.0.1) released to the Foxglove store is not compatible with the current Autoware.

While compatibility fixes have been [merged](https://github.com/kminoda/AutowareFoxgloveConverter/pull/1), no new release has been made since.

This PR aims at making the newest changes release-ready. This includes the following:

- fix build instructions (building is only possible via `yarn`, not `npm`)
- bump version to 0.1.0

Since the maintainer changed to TIER IV, I also had to make the following changes:

- change package name to match TIER IV repo name
- change publisher to TIER IV