### PR TITLE
fix: correct build system in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,18 @@ Note that this repository may not be maintained and thus the destructive changes
 
 ## Develop
 
-Extension development uses the `yarn` package manager to install development dependencies and run build scripts.
+Extension development uses the `npm` package manager to install development dependencies and run build scripts.
 
-To install extension dependencies, run `yarn` from the root of the extension package.
+To install extension dependencies, run `npm install` from the root of the extension package.
 
 ```sh
-yarn install
+npm install
 ```
 
 To build and install the extension into your local Foxglove Studio desktop app, run:
 
 ```sh
-yarn run local-install
+npm run local-install
 ```
 
 Open the `Foxglove Studio` desktop (or `ctrl-R` to refresh if it is already open). Your extension is installed and available within the app.
@@ -45,7 +45,7 @@ Extensions are packaged into `.foxe` files. These files contain the metadata (pa
 Before packaging, make sure to set `name`, `publisher`, `version`, and `description` fields in _package.json_. When ready to distribute the extension, run:
 
 ```sh
-yarn run package
+npm run package
 ```
 
 This command will package the extension into a `.foxe` file in the local directory.


### PR DESCRIPTION
The build system was reverted to npm in https://github.com/tier4/AutowareFoxgloveExtensions/pull/4, however the description in REAME wasn't changed. This PR would fix this issue.