### PR TITLE
fix: remove erroneous bounding box z offset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoware-foxglove-extensions",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoware-foxglove-extensions",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@foxglove/schemas": "^1.8.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ function createCubePrimitive(x: number, y:number, z:number, position: Position, 
       position: {
         x: position.x,
         y: position.y,
-        z: position.z - 0.5 * z,
+        z: position.z,
       },
       orientation,
     },


### PR DESCRIPTION
There was an erroneous offset by -z/2 (z is the bbox height) for Autoware detected objects, causing the bboxes to appear lower than their corresponding points.

Removed the offset.

| Before | After |
|-|-|
| ![before](https://github.com/user-attachments/assets/8ce30379-596e-46eb-be93-410839e93cae) | ![after](https://github.com/user-attachments/assets/2e7185c3-bde4-457d-8059-5f410f720881) |

