### PR TITLE
fix: align ObjectClassification labels with autoware_perception_msgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Aligned `ObjectClassification.label` numbering with [autoware_perception_msgs/ObjectClassification.msg](https://github.com/autowarefoundation/autoware_msgs/blob/main/autoware_perception_msgs/msg/ObjectClassification.msg). Previously `TRUCK`, `TRAILER`, `MOTORCYCLE`, and `BICYCLE` were colored/labeled as different classes, and the internal `colorMap` and `labelMap` numbered the same labels differently.
 - Added `TRAILER`, `ANIMAL`, `HAZARD`, `OVER_DRIVABLE`, and `UNDER_DRIVABLE` entries to the label map. Removed the `CYCLIST` label that is not defined by any Autoware message.
+- Assigned dedicated colors to `ANIMAL` (orange), `HAZARD` (magenta), `OVER_DRIVABLE` (cyan), and `UNDER_DRIVABLE` (purple) so they no longer collapse onto the white `UNKNOWN` fallback.
 
 ## 0.1.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # AutowareFoxgloveConverter version history
 
+## 0.1.4
+
+- Aligned `ObjectClassification.label` numbering with [autoware_perception_msgs/ObjectClassification.msg](https://github.com/autowarefoundation/autoware_msgs/blob/main/autoware_perception_msgs/msg/ObjectClassification.msg). Previously `TRUCK`, `TRAILER`, `MOTORCYCLE`, and `BICYCLE` were colored/labeled as different classes, and the internal `colorMap` and `labelMap` numbered the same labels differently.
+- Added `TRAILER`, `ANIMAL`, `HAZARD`, `OVER_DRIVABLE`, and `UNDER_DRIVABLE` entries to the label map. Removed the `CYCLIST` label that is not defined by any Autoware message.
+
+## 0.1.3
+
+- Fixed vertical bounding box position by adding `z/2` offset
+
 ## 0.1.2
 
 - Added support for:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "autoware-foxglove-extensions",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "autoware-foxglove-extensions",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@foxglove/schemas": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Support for Autoware in Foxglove Studio",
   "publisher": "tier4",
   "homepage": "https://github.com/tier4/AutowareFoxgloveExtensions",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "license": "Apache-2.0",
   "main": "./dist/extension.js",
   "keywords": [],

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,14 +16,15 @@ type Color = {
   a: number;
 };
 
+// Label numbering follows autoware_perception_msgs/ObjectClassification.msg.
 const colorMap: Record<number, Color> = {
   0: { r: 1.0, g: 1.0, b: 1.0, a: 0.5 }, // UNKNOWN // white // hex: #FFFFFF
   1: { r: 1.0, g: 0.0, b: 0.0, a: 0.5 }, // CAR // red // hex: #FF0000
-  2: { r: 1.0, g: 0.5, b: 0.5, a: 0.5 }, // BICYCLE // pink // hex: #FF8080
+  2: { r: 0.0, g: 0.5, b: 1.0, a: 0.5 }, // TRUCK // blue // hex: #0080FF
   3: { r: 0.0, g: 0.5, b: 1.0, a: 0.5 }, // BUS // blue // hex: #0080FF
-  4: { r: 0.0, g: 0.5, b: 1.0, a: 0.5 }, // TRUCK // blue // hex: #0080FF
-  5: { r: 1.0, g: 0.5, b: 0.5, a: 0.5 }, // CYCLIST // pink // hex: #FF8080
-  6: { r: 1.0, g: 1.0, b: 0.5, a: 0.5 }, // MOTORCYCLE // yellow // hex: #FFFF80
+  4: { r: 0.0, g: 0.5, b: 1.0, a: 0.5 }, // TRAILER // blue // hex: #0080FF
+  5: { r: 1.0, g: 1.0, b: 0.5, a: 0.5 }, // MOTORCYCLE // yellow // hex: #FFFF80
+  6: { r: 1.0, g: 0.5, b: 0.5, a: 0.5 }, // BICYCLE // pink // hex: #FF8080
   7: { r: 0.75, g: 1.0, b: 0.25, a: 0.5 }, // PEDESTRIAN // green // hex: #BFFF40
 };
 
@@ -39,21 +40,29 @@ const labelMap: Record<number, string> = {
   1: "CAR",
   2: "TRUCK",
   3: "BUS",
-  4: "BICYCLE",
-  5: "MOTORBIKE",
-  6: "PEDESTRIAN",
-  7: "ANIMAL",
+  4: "TRAILER",
+  5: "MOTORCYCLE",
+  6: "BICYCLE",
+  7: "PEDESTRIAN",
+  8: "ANIMAL",
+  9: "HAZARD",
+  10: "OVER_DRIVABLE",
+  11: "UNDER_DRIVABLE",
 };
 
 enum Classification {
   UNKNOWN = 0,
   CAR = 1,
-  BICYCLE = 2,
+  TRUCK = 2,
   BUS = 3,
-  TRUCK = 4,
-  CYCLIST = 5,
-  MOTORCYCLE = 6,
+  TRAILER = 4,
+  MOTORCYCLE = 5,
+  BICYCLE = 6,
   PEDESTRIAN = 7,
+  ANIMAL = 8,
+  HAZARD = 9,
+  OVER_DRIVABLE = 10,
+  UNDER_DRIVABLE = 11,
 }
 
 // 3D

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,10 @@ const colorMap: Record<number, Color> = {
   5: { r: 1.0, g: 1.0, b: 0.5, a: 0.5 }, // MOTORCYCLE // yellow // hex: #FFFF80
   6: { r: 1.0, g: 0.5, b: 0.5, a: 0.5 }, // BICYCLE // pink // hex: #FF8080
   7: { r: 0.75, g: 1.0, b: 0.25, a: 0.5 }, // PEDESTRIAN // green // hex: #BFFF40
+  8: { r: 1.0, g: 0.5, b: 0.0, a: 0.5 }, // ANIMAL // orange // hex: #FF8000
+  9: { r: 1.0, g: 0.0, b: 1.0, a: 0.5 }, // HAZARD // magenta // hex: #FF00FF
+  10: { r: 0.0, g: 1.0, b: 1.0, a: 0.5 }, // OVER_DRIVABLE // cyan // hex: #00FFFF
+  11: { r: 0.5, g: 0.25, b: 1.0, a: 0.5 }, // UNDER_DRIVABLE // purple // hex: #8040FF
 };
 
 const trafficLightColorMap: Record<number, Color> = {


### PR DESCRIPTION
## Summary

The bounding box class numbering used by this extension did not match `autoware_perception_msgs/ObjectClassification.msg`, even though the extension subscribes to `autoware_perception_msgs/msg/{DetectedObjects,TrackedObjects,PredictedObjects}` (and the equivalent `autoware_auto_perception_msgs/...`).

Worse, inside `src/index.ts` the `colorMap`, the `labelMap`, and the `Classification` enum each used a *different* numbering, so bounding box colors and the displayed class names disagreed with each other:

| Real class (autoware label) | Box color (before) | 2D label text (before) |
|---|---|---|
| TRUCK (2)        | pink (BICYCLE)       | "TRUCK"     |
| BUS (3)          | blue                 | "BUS"       |
| TRAILER (4)      | blue (TRUCK)         | "BICYCLE"   |
| MOTORCYCLE (5)   | pink (CYCLIST)       | "MOTORBIKE" |
| BICYCLE (6)      | yellow (MOTORCYCLE)  | "PEDESTRIAN"|
| PEDESTRIAN (7)   | green                | "ANIMAL"    |
| ANIMAL/HAZARD/OVER_DRIVABLE/UNDER_DRIVABLE (8-11) | white fallback | "UNKNOWN" fallback |

## Changes

- `src/index.ts`
  - Re-numbered `colorMap`, `labelMap`, and the `Classification` enum to match `autoware_perception_msgs/ObjectClassification.msg`.
  - Added entries for `TRAILER`, `ANIMAL`, `HAZARD`, `OVER_DRIVABLE`, `UNDER_DRIVABLE`.
  - Removed the `CYCLIST` label (not defined by any Autoware message).
  - `TRAILER` shares the same blue as `TRUCK` / `BUS`. `ANIMAL`, `HAZARD`, `OVER_DRIVABLE`, and `UNDER_DRIVABLE` get dedicated colors so they are visually distinct from the white `UNKNOWN` fallback.
- `package.json`, `package-lock.json`: bump version to `0.1.4`.
- `CHANGELOG.md`: add a `0.1.4` entry, and backfill the missing `0.1.3` entry (z/2 bbox vertical offset fix from #7).

### Aligned label table

| label | Class             | Color   |
|------:|-------------------|---------|
| 0     | UNKNOWN           | white   |
| 1     | CAR               | red     |
| 2     | TRUCK             | blue    |
| 3     | BUS               | blue    |
| 4     | TRAILER           | blue    |
| 5     | MOTORCYCLE        | yellow  |
| 6     | BICYCLE           | pink    |
| 7     | PEDESTRIAN        | green   |
| 8     | ANIMAL            | orange  |
| 9     | HAZARD            | magenta |
| 10    | OVER_DRIVABLE     | cyan    |
| 11    | UNDER_DRIVABLE    | purple  |

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` reports the same 198 pre-existing errors as `main` (no new lint issues introduced by this PR)
- [ ] Visual check in Foxglove Studio with an Autoware bag containing `DetectedObjects` / `TrackedObjects` / `PredictedObjects`: confirm trucks render in blue (previously pink) and bicycles render in pink (previously yellow).
- [ ] For 2D ROI (`DetectedObjectsWithFeature`): confirm the labels in the annotation text match the actual class (e.g. PEDESTRIAN bbox no longer shows "ANIMAL").